### PR TITLE
RSDK-9470: gps module logs a lot after cord yank

### DIFF
--- a/gpsutils/serial_data_reader.go
+++ b/gpsutils/serial_data_reader.go
@@ -67,6 +67,7 @@ func NewSerialDataReader(
 
 func (dr *SerialDataReader) backgroundWorker(cancelCtx context.Context) {
 	defer close(dr.data)
+	readErrCount := 0
 
 	r := bufio.NewReader(dr.dev)
 	for {
@@ -80,7 +81,10 @@ func (dr *SerialDataReader) backgroundWorker(cancelCtx context.Context) {
 
 		line, err := r.ReadString('\n')
 		if err != nil {
-			dr.logger.CErrorf(cancelCtx, "can't read gps serial %s", err)
+			if readErrCount < 5 {
+				dr.logger.CDebug(cancelCtx, "can't read gps serial %s", err)
+			}
+			readErrCount++
 			continue // The line has bogus data; don't put it in the channel.
 		}
 

--- a/gpsutils/serial_data_reader.go
+++ b/gpsutils/serial_data_reader.go
@@ -81,12 +81,16 @@ func (dr *SerialDataReader) backgroundWorker(cancelCtx context.Context) {
 
 		line, err := r.ReadString('\n')
 		if err != nil {
-			if readErrCount < 5 {
+			// if this error has occured 5 times in a row, switch to debug level logs
+			if readErrCount > 5 {
 				dr.logger.CDebugf(cancelCtx, "can't read gps serial %s", err)
+			} else {
+				dr.logger.CErrorf(cancelCtx, "can't read gps serial %s", err)
 			}
 			readErrCount++
 			continue // The line has bogus data; don't put it in the channel.
 		}
+		readErrCount = 0
 
 		select {
 		case <-cancelCtx.Done():

--- a/gpsutils/serial_data_reader.go
+++ b/gpsutils/serial_data_reader.go
@@ -82,7 +82,7 @@ func (dr *SerialDataReader) backgroundWorker(cancelCtx context.Context) {
 		line, err := r.ReadString('\n')
 		if err != nil {
 			if readErrCount < 5 {
-				dr.logger.CDebug(cancelCtx, "can't read gps serial %s", err)
+				dr.logger.CDebugf(cancelCtx, "can't read gps serial %s", err)
 			}
 			readErrCount++
 			continue // The line has bogus data; don't put it in the channel.


### PR DESCRIPTION
limit error log in gps background worker to 5 logs, also change it to debug 